### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ special networking properties:
 
 * [Gateway](jobs/gateway): allows to add a [default gateway](http://en.wikipedia.org/wiki/Default_gateway) to your vms
 * [NAT](jobs/nat): allows to create a [NAT](http://en.wikipedia.org/wiki/Network_address_translation) vm using [iptables](http://en.wikipedia.org/wiki/Iptables)
+* [IPtables](jobs/iptables): allows to add custom iptables rules [iptables](http://en.wikipedia.org/wiki/Iptables)
 * [Routes](jobs/routes): allows to add [IP routes](http://en.wikipedia.org/wiki/Routing_table) to your vms
 * [MTU](jobs/set_mtu): allows to override [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit) on your vms
 
@@ -18,18 +19,19 @@ Add the networking release jobs and properties to your BOSH deployment manifest:
 releases:
   - name: cf
     version: latest
-  - name: networking                                # +
-    version: latest                                 # +
+  - name: networking                                  # +
+    version: latest                                   # +
 ...
 instance_groups:
   - name: haproxy
     jobs:
-      - name: nat                                   # +
-        release: networking                         # +
-        properties:                                 # +
-          networking.nat:                           # +
-            in_interface: eth0                      # +
-            out_interface: eth1                     # +
+      - name: nat                                     # +
+        release: networking                           # +
+        properties:                                   # +
+          networking:                                 # +
+            nat:                                      # +
+              in_interface: eth0                      # +
+              out_interface: eth1                     # +
       - name: haproxy
         release: cf
     networks:
@@ -38,32 +40,47 @@ instance_groups:
       - name: public
         static_ips:
           - 1.2.3.4
+  - name: natgateway
+    jobs:
+      - name: nat
+        release: networking
+        properties:
+          networking:
+            nat:
+              out_interface: eth0
+      - name: iptables
+        release: networking
+        properties:
+          nat:
+            POSTROUTING:
+            - -o eth0 -j MASQUERADE
   - name: router
     jobs:
-      - name: gateway                               # +
-        release: networking                         # +
-        properties:                                 # +
-          networking.gateway:                       # +
-            default: 0.haproxy.default.cf.microbosh # +
-      - name: routes                                # +
-        release: networking                         # +
-        properties:                                 # +
-          networking.routes:                        # +
-            - net: 192.168.1.0                      # +
-              netmask: 255.255.255.224              # +
-              interface: eth0                       # +
-              gateway: 10.9.9.1                     # +
-      - name: port_forwarding                       # +
-        release: networking                         # +
-        properties:                                 # +
+      - name: gateway                                 # +
+        release: networking                           # +
+        properties:                                   # +
+          networking:                                 # +
+            gateway:                                  # +
+              default: 0.haproxy.default.cf.microbosh # +
+      - name: routes                                  # +
+        release: networking                           # +
+        properties:                                   # +
+          networking.routes:                          # +
+            - net: 192.168.1.0                        # +
+              netmask: 255.255.255.224                # +
+              interface: eth0                         # +
+              gateway: 10.9.9.1                       # +
+      - name: port_forwarding                         # +
+        release: networking                           # +
+        properties:                                   # +
           networking:
-            port_forwarding:                        # +
-              - external_port: 9200                 # +
-                internal_ip: 1.2.3.10               # +
-                internal_port: 9200                 # +
-              - external_port: 9292                 # +
-                internal_ip: 1.2.3.11               # +
-                internal_port: 9292                 # +
+            port_forwarding:                          # +
+              - external_port: 9200                   # +
+                internal_ip: 1.2.3.10                 # +
+                internal_port: 9200                   # +
+              - external_port: 9292                   # +
+                internal_ip: 1.2.3.11                 # +
+                internal_port: 9292                   # +
       - name: gorouter
         release: cf
 ```


### PR DESCRIPTION
using "networking.nat" as a property no longer works with latest versions of BOSH. Need to use staggered 
networking:
  nat:

I have also added a new instance group to documentation that I used to create a NAT gateway like in https://cloud.google.com/vpc/docs/special-configurations

With an example using the newer iptables job.